### PR TITLE
refactor: change npm scope from @ariadne to @ariadnejs

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -44,7 +44,7 @@ npm run release
 ## Configuration
 
 Our monorepo is configured with:
-- **Linked packages**: `@ariadne/core` and `@ariadne/types` are linked, meaning they'll always be released together with the same version
+- **Linked packages**: `@ariadnejs/core` and `@ariadnejs/types` are linked, meaning they'll always be released together with the same version
 - **Access**: Public packages on npm
 - **Base branch**: `main`
 

--- a/.changeset/ariadnejs-scope.md
+++ b/.changeset/ariadnejs-scope.md
@@ -1,0 +1,38 @@
+---
+"@ariadnejs/core": major
+"@ariadnejs/types": major
+---
+
+**BREAKING CHANGE:** Changed npm package scope from `@ariadne/*` to `@ariadnejs/*`
+
+Due to the `@ariadne` organization already being taken on npm, we've changed our package scope to `@ariadnejs`. Update your imports:
+
+**Before:**
+```json
+{
+  "dependencies": {
+    "@ariadne/core": "^0.5.9",
+    "@ariadne/types": "^0.5.9"
+  }
+}
+```
+
+**After:**
+```json
+{
+  "dependencies": {
+    "@ariadnejs/core": "^1.0.0",
+    "@ariadnejs/types": "^1.0.0"
+  }
+}
+```
+
+```typescript
+// Before
+import { Definition } from '@ariadne/types';
+import { RefScope } from '@ariadne/core';
+
+// After
+import { Definition } from '@ariadnejs/types';
+import { RefScope } from '@ariadnejs/core';
+```

--- a/.changeset/ariadnejs-scope.md
+++ b/.changeset/ariadnejs-scope.md
@@ -1,9 +1,9 @@
 ---
-"@ariadnejs/core": major
-"@ariadnejs/types": major
+"@ariadnejs/core": patch
+"@ariadnejs/types": patch
 ---
 
-**BREAKING CHANGE:** Changed npm package scope from `@ariadne/*` to `@ariadnejs/*`
+Changed npm package scope from `@ariadne/*` to `@ariadnejs/*`
 
 Due to the `@ariadne` organization already being taken on npm, we've changed our package scope to `@ariadnejs`. Update your imports:
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@ariadne/core", "@ariadne/types"]],
+  "linked": [["@ariadnejs/core", "@ariadnejs/types"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -126,7 +126,7 @@ jobs:
           echo '${{ needs.release.outputs.publishedPackages }}' > published.json
           VERSION=$(node -e "
             const packages = JSON.parse(require('fs').readFileSync('published.json', 'utf8'));
-            const core = packages.find(p => p.name === '@ariadne/core');
+            const core = packages.find(p => p.name === '@ariadnejs/core');
             console.log(core ? core.version : packages[0].version);
           ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -153,8 +153,8 @@ jobs:
             ## 📥 Installation
             
             ```bash
-            npm install @ariadne/core@${{ steps.parse.outputs.version }}
-            npm install @ariadne/types@${{ steps.parse.outputs.version }}
+            npm install @ariadnejs/core@${{ steps.parse.outputs.version }}
+            npm install @ariadnejs/types@${{ steps.parse.outputs.version }}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,5 @@ jobs:
         
       - name: Check packages
         run: |
-          npm pack --dry-run -w @ariadne/types
-          npm pack --dry-run -w @ariadne/core
+          npm pack --dry-run -w @ariadnejs/types
+          npm pack --dry-run -w @ariadnejs/core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ git commit -m "feat: add new symbol resolution feature"
 
 # Create a changeset
 npm run changeset
-# Select @ariadne/core
+# Select @ariadnejs/core
 # Select "minor"
 # Write: "Added new symbol resolution feature for better cross-file support"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Find references and definitions in your codebase using tree-sitter. Ariadne prov
 ## Installation
 
 ```bash
-npm install @ariadne/core
+npm install @ariadnejs/core
 ```
 
 Ariadne includes prebuilt binaries for common platforms, so you don't need build tools installed. If prebuilt binaries aren't available for your platform, it will automatically build from source. See [prebuild documentation](docs/prebuild-binaries.md) for more details.
@@ -25,7 +25,7 @@ Ariadne includes prebuilt binaries for common platforms, so you don't need build
 If you only need TypeScript type definitions without the implementation (e.g., for webviews or lightweight environments), you can install the types-only package:
 
 ```bash
-npm install @ariadne/types
+npm install @ariadnejs/types
 ```
 
 This package contains zero runtime code and is ideal for:
@@ -34,12 +34,12 @@ This package contains zero runtime code and is ideal for:
 - Type-safe message passing between processes
 - Projects that only need type definitions for interoperability
 
-See the [@ariadne/types documentation](packages/ariadne-types/README.md) for more details.
+See the [@ariadnejs/types documentation](packages/ariadne-types/README.md) for more details.
 
 ## Quick Start
 
 ```typescript
-import { Project } from "@ariadne/core";
+import { Project } from "@ariadnejs/core";
 
 // Create a project instance
 const project = new Project();

--- a/backlog/drafts/ast-climber-types-package.md
+++ b/backlog/drafts/ast-climber-types-package.md
@@ -2,20 +2,20 @@
 
 ## Overview
 
-Create a separate `@ariadne/types` package that exports only type definitions from @ariadne/core, with zero runtime code. This addresses the need for ariadne types in environments where bundle size is critical (like webviews) without requiring the full @ariadne/core package.
+Create a separate `@ariadnejs/types` package that exports only type definitions from @ariadnejs/core, with zero runtime code. This addresses the need for ariadne types in environments where bundle size is critical (like webviews) without requiring the full @ariadnejs/core package.
 
 ## Problem Statement
 
-The Code Charter VSCode extension's webview needs to use ariadne's type definitions for proper type safety across the extension-webview boundary. However, installing the full @ariadne/core package in the webview would unnecessarily bloat the bundle size since only types are needed - no runtime functionality is required.
+The Code Charter VSCode extension's webview needs to use ariadne's type definitions for proper type safety across the extension-webview boundary. However, installing the full @ariadnejs/core package in the webview would unnecessarily bloat the bundle size since only types are needed - no runtime functionality is required.
 
 ## Proposed Solution
 
-Publish a `@ariadne/types` package that contains only TypeScript type definitions extracted from @ariadne/core.
+Publish a `@ariadnejs/types` package that contains only TypeScript type definitions extracted from @ariadnejs/core.
 
 ### Package Structure
 
 ```
-@ariadne/types/
+@ariadnejs/types/
 ├── package.json
 ├── index.d.ts
 ├── types/
@@ -30,9 +30,9 @@ Publish a `@ariadne/types` package that contains only TypeScript type definition
 
 ```json
 {
-  "name": "@ariadne/types",
+  "name": "@ariadnejs/types",
   "version": "1.0.0",
-  "description": "TypeScript type definitions for @ariadne/core",
+  "description": "TypeScript type definitions for @ariadnejs/core",
   "types": "index.d.ts",
   "files": ["index.d.ts", "types/**/*.d.ts"],
   "peerDependencies": {
@@ -120,29 +120,29 @@ export interface DefMetadata {
 
 ## Implementation Steps
 
-1. **Extract type definitions** from @ariadne/core source code
-2. **Create new npm package** `@ariadne/types`
-3. **Set up build process** to keep types in sync with main @ariadne/core package
-4. **Publish to npm** with same versioning as @ariadne/core
-5. **Update @ariadne/core** to optionally depend on @ariadne/types for its own type exports
+1. **Extract type definitions** from @ariadnejs/core source code
+2. **Create new npm package** `@ariadnejs/types`
+3. **Set up build process** to keep types in sync with main @ariadnejs/core package
+4. **Publish to npm** with same versioning as @ariadnejs/core
+5. **Update @ariadnejs/core** to optionally depend on @ariadnejs/types for its own type exports
 
 ## Benefits
 
 1. **Zero runtime overhead** - Only TypeScript definitions, no JavaScript code
 2. **Small package size** - Just a few KB of type definitions
 3. **Perfect for webviews** - Can use types without bundle bloat
-4. **Version synchronization** - Can be kept in sync with @ariadne/core releases
-5. **Broader ecosystem support** - Other tools can use ariadne types without the full @ariadne/core package
+4. **Version synchronization** - Can be kept in sync with @ariadnejs/core releases
+5. **Broader ecosystem support** - Other tools can use ariadne types without the full @ariadnejs/core package
 
 ## Maintenance Strategy
 
-- **Automated sync**: Set up CI to extract and publish types when @ariadne/core releases
-- **Version matching**: Use same version numbers as @ariadne/core for clarity
-- **Breaking changes**: Only when @ariadne/core has breaking type changes
+- **Automated sync**: Set up CI to extract and publish types when @ariadnejs/core releases
+- **Version matching**: Use same version numbers as @ariadnejs/core for clarity
+- **Breaking changes**: Only when @ariadnejs/core has breaking type changes
 
 ## Alternative Approaches Considered
 
-1. **`@types/ariadne`** - Not appropriate since @ariadne/core is already TypeScript
+1. **`@types/ariadne`** - Not appropriate since @ariadnejs/core is already TypeScript
 2. **Type exports from main package** - Still requires installing full package
 3. **Duplicating types in consumer** - Maintenance burden and sync issues
 
@@ -151,7 +151,7 @@ export interface DefMetadata {
 In webview code:
 
 ```typescript
-import type { CallGraph, Def, CallGraphNode } from "@ariadne/types";
+import type { CallGraph, Def, CallGraphNode } from "@ariadnejs/types";
 
 // Use types for proper type safety without runtime dependency
 function processCallGraph(graph: CallGraph): void {
@@ -163,15 +163,15 @@ In extension code (can use either):
 
 ```typescript
 // Option 1: Use full ariadne
-import { CallGraph, get_call_graph } from "@ariadne/core";
+import { CallGraph, get_call_graph } from "@ariadnejs/core";
 
 // Option 2: Just types (if only needed for type annotations)
-import type { CallGraph } from "@ariadne/types";
+import type { CallGraph } from "@ariadnejs/types";
 ```
 
 ## Next Steps
 
-1. Create the @ariadne/types package structure
-2. Extract current type definitions from @ariadne/core
+1. Create the @ariadnejs/types package structure
+2. Extract current type definitions from @ariadnejs/core
 3. Set up npm package and publish
-4. Update Code Charter to use @ariadne/types in webview
+4. Update Code Charter to use @ariadnejs/types in webview

--- a/docs/call-graph-api.md
+++ b/docs/call-graph-api.md
@@ -18,7 +18,7 @@ The call graph API consists of three levels:
 Returns all definitions (functions, methods, classes, variables) in a file.
 
 ```typescript
-import { get_definitions } from '@ariadne/core';
+import { get_definitions } from '@ariadnejs/core';
 
 const definitions = get_definitions('src/utils.ts');
 const functions = definitions.filter(d => d.symbol_kind === 'function');
@@ -52,7 +52,7 @@ const callGraph = project.get_call_graph({
 });
 
 // Using standalone function
-import { get_call_graph } from '@ariadne/core';
+import { get_call_graph } from '@ariadnejs/core';
 const callGraph = get_call_graph('./src', options);
 ```
 
@@ -85,7 +85,7 @@ Ariadne uses a consistent symbol naming scheme for identifying functions across 
   - `lib/math#<anonymous_line_42_col_10>` - Anonymous function
 
 ```typescript
-import { get_symbol_id, parse_symbol_id } from '@ariadne/core';
+import { get_symbol_id, parse_symbol_id } from '@ariadnejs/core';
 
 // Generate symbol ID for a definition
 const symbolId = get_symbol_id(def); // "src/utils#processData"

--- a/docs/npm-package-migration-guide.md
+++ b/docs/npm-package-migration-guide.md
@@ -26,7 +26,7 @@ npm test
 npm publish --access public
 ```
 
-### 1.2 Publish @ariadne/types
+### 1.2 Publish @ariadnejs/types
 
 ```bash
 # Navigate to the types package
@@ -53,13 +53,13 @@ git checkout -b deprecate-refscope
 {
   "name": "refscope",
   "version": "0.5.7",
-  "description": "DEPRECATED: This package has been renamed to @ariadne/core. Please install @ariadne/core instead.",
+  "description": "DEPRECATED: This package has been renamed to @ariadnejs/core. Please install @ariadnejs/core instead.",
   "main": "index.js",
   "scripts": {
     "postinstall": "node deprecation-notice.js"
   },
   "dependencies": {
-    "@ariadne/core": "^0.5.6"
+    "@ariadnejs/core": "^0.5.6"
   }
 }
 ```
@@ -71,22 +71,22 @@ git checkout -b deprecate-refscope
 console.log('\n' + '='.repeat(70));
 console.log('DEPRECATION NOTICE');
 console.log('='.repeat(70));
-console.log('\nThe "refscope" package has been renamed to "@ariadne/core".');
+console.log('\nThe "refscope" package has been renamed to "@ariadnejs/core".');
 console.log('\nPlease update your dependencies:');
 console.log('  npm uninstall refscope');
-console.log('  npm install @ariadne/core');
+console.log('  npm install @ariadnejs/core');
 console.log('\nOr update your package.json:');
-console.log('  "refscope": "^0.5.6" → "@ariadne/core": "^0.5.6"');
+console.log('  "refscope": "^0.5.6" → "@ariadnejs/core": "^0.5.6"');
 console.log('\n' + '='.repeat(70) + '\n');
 ```
 
 4. Create a minimal `index.js` that re-exports ariadne:
 ```javascript
-// Re-export everything from @ariadne/core
-module.exports = require('@ariadne/core');
+// Re-export everything from @ariadnejs/core
+module.exports = require('@ariadnejs/core');
 
 // Show deprecation warning when imported
-console.warn('[DEPRECATION] "refscope" has been renamed to "@ariadne/core". Please update your imports.');
+console.warn('[DEPRECATION] "refscope" has been renamed to "@ariadnejs/core". Please update your imports.');
 ```
 
 ### 2.2 Publish the Deprecation Version
@@ -96,7 +96,7 @@ console.warn('[DEPRECATION] "refscope" has been renamed to "@ariadne/core". Plea
 npm publish
 
 # Mark the package as deprecated on npm
-npm deprecate refscope@"*" "This package has been renamed to @ariadne/core. Please install @ariadne/core instead."
+npm deprecate refscope@"*" "This package has been renamed to @ariadnejs/core. Please install @ariadnejs/core instead."
 ```
 
 ## Step 3: Update Documentation and Announcements
@@ -115,11 +115,11 @@ This project has been renamed from `refscope` to `ariadne`.
 
 ### For users:
 - Uninstall `refscope`: `npm uninstall refscope`
-- Install `@ariadne/core`: `npm install @ariadne/core`
-- Update imports: `from 'refscope'` → `from '@ariadne/core'`
+- Install `@ariadnejs/core`: `npm install @ariadnejs/core`
+- Update imports: `from 'refscope'` → `from '@ariadnejs/core'`
 
 ### For TypeScript users:
-- The types package is now `@ariadne/types`
+- The types package is now `@ariadnejs/types`
 - Update your imports accordingly
 
 All functionality remains the same, only the package name has changed.
@@ -131,7 +131,7 @@ All functionality remains the same, only the package name has changed.
 
 Keep an eye on:
 - https://www.npmjs.com/package/refscope (should decrease)
-- https://www.npmjs.com/package/@ariadne/core (should increase)
+- https://www.npmjs.com/package/@ariadnejs/core (should increase)
 
 ### 4.2 Respond to Issues
 
@@ -161,15 +161,15 @@ If critical issues arise:
 ## FAQ for Users
 
 ### Q: Will my existing code break?
-A: If you're using the deprecated refscope package, you'll see warnings but your code will continue to work initially. However, you should migrate to @ariadne/core as soon as possible.
+A: If you're using the deprecated refscope package, you'll see warnings but your code will continue to work initially. However, you should migrate to @ariadnejs/core as soon as possible.
 
 ### Q: Do I need to change my code?
 A: Only the import statements need to change:
-- `import { Project } from 'refscope'` → `import { Project } from '@ariadne/core'`
-- `require('refscope')` → `require('@ariadne/core')`
+- `import { Project } from 'refscope'` → `import { Project } from '@ariadnejs/core'`
+- `require('refscope')` → `require('@ariadnejs/core')`
 
 ### Q: What about TypeScript types?
-A: Install `@ariadne/types` instead of `refscope-types`.
+A: Install `@ariadnejs/types` instead of `refscope-types`.
 
 ### Q: Why the name change?
 A: The new name "ariadne" reflects the library's purpose - like Ariadne's thread in Greek mythology, it helps you navigate through the labyrinth of your codebase to find references and definitions.

--- a/docs/prebuild-binaries.md
+++ b/docs/prebuild-binaries.md
@@ -4,7 +4,7 @@ Ariadne includes support for prebuilt binaries to improve the installation exper
 
 ## How it Works
 
-1. When you run `npm install @ariadne/core`, the postinstall script automatically checks for prebuilt binaries for your platform
+1. When you run `npm install @ariadnejs/core`, the postinstall script automatically checks for prebuilt binaries for your platform
 2. If prebuilt binaries are available, they are downloaded and extracted
 3. If prebuilt binaries are not available, the installation falls back to building from source
 
@@ -21,7 +21,7 @@ Prebuilt binaries are provided for:
 If you prefer to build from source or need to use Ariadne on an unsupported platform, you can force building from source:
 
 ```bash
-npm install @ariadne/core --build-from-source
+npm install @ariadnejs/core --build-from-source
 ```
 
 ## Troubleshooting

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -58,8 +58,8 @@
 ## After Publishing
 
 1. **Verify Publication**
-   - [ ] Check package on npmjs.com: https://www.npmjs.com/package/@ariadne/core
-   - [ ] Test installation: `npm install @ariadne/core` in a new project
+   - [ ] Check package on npmjs.com: https://www.npmjs.com/package/@ariadnejs/core
+   - [ ] Test installation: `npm install @ariadnejs/core` in a new project
    - [ ] Verify types work correctly in TypeScript
 
 2. **Announcement**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,14 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@ariadne/core": {
+    "node_modules/@ariadnejs/core": {
       "resolved": "packages/core",
       "link": true
     },
-    "node_modules/@ariadne/types": {
+    "node_modules/@ariadnejs/types": {
       "resolved": "packages/types",
       "link": true
     },
@@ -3192,12 +3192,12 @@
       "license": "ISC"
     },
     "packages/core": {
-      "name": "@ariadne/core",
-      "version": "0.5.8",
+      "name": "@ariadnejs/core",
+      "version": "0.5.9",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@ariadne/types": "file:../types",
+        "@ariadnejs/types": "0.5.9",
         "js-yaml": "^4.1.0",
         "tar": "^6.2.1",
         "tree-sitter": "0.21.1",
@@ -3231,8 +3231,8 @@
       }
     },
     "packages/types": {
-      "name": "@ariadne/types",
-      "version": "0.5.8",
+      "name": "@ariadnejs/types",
+      "version": "0.5.9",
       "license": "ISC",
       "devDependencies": {
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w @ariadne/types && npm run build -w @ariadne/core",
+    "build": "npm run build -w @ariadnejs/types && npm run build -w @ariadnejs/core",
     "test": "npm run test --workspaces",
     "clean": "npm run clean --workspaces && rm -rf node_modules",
     "changeset": "changeset",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @ariadne/core
+# @ariadnejs/core
 
 ## 0.5.9
 
@@ -6,8 +6,8 @@
 
 - 4eaa992: Reorganized the project into a monorepo structure with separate packages for core functionality and types.
 
-  - Created `@ariadne/core` package containing all implementation code
-  - Created `@ariadne/types` package with zero-dependency TypeScript types
+  - Created `@ariadnejs/core` package containing all implementation code
+  - Created `@ariadnejs/types` package with zero-dependency TypeScript types
   - Set up npm workspaces for managing the monorepo
   - Configured changesets for coordinated versioning and releasing
   - Integrated GitHub Actions for automated releases with prebuilt binaries

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,17 +1,17 @@
-# @ariadne/core
+# @ariadnejs/core
 
 Core functionality for Ariadne - Find references and definitions in your codebase using tree-sitter.
 
 ## Installation
 
 ```bash
-npm install @ariadne/core
+npm install @ariadnejs/core
 ```
 
 ## Usage
 
 ```typescript
-import { Project } from '@ariadne/core';
+import { Project } from '@ariadnejs/core';
 
 const project = new Project();
 await project.add_or_update_file('src/index.ts', sourceCode);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/CRJFisher/ariadne#readme",
   "dependencies": {
-    "@ariadnejs/types": "file:../types",
+    "@ariadnejs/types": "0.5.9",
     "js-yaml": "^4.1.0",
     "tar": "^6.2.1",
     "tree-sitter": "0.21.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ariadne/core",
+  "name": "@ariadnejs/core",
   "version": "0.5.9",
   "description": "Core functionality for Ariadne - Find references and definitions in your codebase using tree-sitter",
   "main": "dist/index.js",
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/CRJFisher/ariadne#readme",
   "dependencies": {
-    "@ariadne/types": "file:../types",
+    "@ariadnejs/types": "file:../types",
     "js-yaml": "^4.1.0",
     "tar": "^6.2.1",
     "tree-sitter": "0.21.1",

--- a/packages/core/src/edit.ts
+++ b/packages/core/src/edit.ts
@@ -1,7 +1,7 @@
-import { Point, Edit } from '@ariadne/types';
+import { Point, Edit } from '@ariadnejs/types';
 
 // Re-export Edit for backward compatibility
-export { Edit } from '@ariadne/types';
+export { Edit } from '@ariadnejs/types';
 
 /**
  * Creates an Edit object from a text change

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -25,7 +25,7 @@ import {
   CallGraphEdge,
   CallGraph,
   IScopeGraph
-} from '@ariadne/types';
+} from '@ariadnejs/types';
 
 // Re-export types for backward compatibility
 export {
@@ -52,9 +52,9 @@ export {
   CallGraphEdge,
   CallGraph,
   IScopeGraph
-} from '@ariadne/types';
+} from '@ariadnejs/types';
 
-// All types are imported from @ariadne/types above
+// All types are imported from @ariadnejs/types above
 
 // The main graph structure
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,9 +1,9 @@
 import Parser from 'tree-sitter';
 import { SyntaxNode } from 'tree-sitter';
-import { ExtractedContext } from '@ariadne/types';
+import { ExtractedContext } from '@ariadnejs/types';
 
-// Re-export clean types from @ariadne/types
-export { ExtractedContext } from '@ariadne/types';
+// Re-export clean types from @ariadnejs/types
+export { ExtractedContext } from '@ariadnejs/types';
 
 // Types that depend on tree-sitter stay in core
 export interface LanguageConfig {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @ariadne/types
+# @ariadnejs/types
 
 ## 0.5.9
 
@@ -6,8 +6,8 @@
 
 - 4eaa992: Reorganized the project into a monorepo structure with separate packages for core functionality and types.
 
-  - Created `@ariadne/core` package containing all implementation code
-  - Created `@ariadne/types` package with zero-dependency TypeScript types
+  - Created `@ariadnejs/core` package containing all implementation code
+  - Created `@ariadnejs/types` package with zero-dependency TypeScript types
   - Set up npm workspaces for managing the monorepo
   - Configured changesets for coordinated versioning and releasing
   - Integrated GitHub Actions for automated releases with prebuilt binaries

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,17 +1,17 @@
-# @ariadne/types
+# @ariadnejs/types
 
 TypeScript type definitions for Ariadne.
 
 ## Installation
 
 ```bash
-npm install @ariadne/types
+npm install @ariadnejs/types
 ```
 
 ## Usage
 
 ```typescript
-import { Def, Ref, CallGraph } from '@ariadne/types';
+import { Def, Ref, CallGraph } from '@ariadnejs/types';
 
 // Use the types in your TypeScript code
 const definition: Def = {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ariadne/types",
+  "name": "@ariadnejs/types",
   "version": "0.5.9",
   "description": "TypeScript type definitions for Ariadne",
   "main": "dist/index.js",

--- a/packages/types/tests/types.test.ts
+++ b/packages/types/tests/types.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Scoping } from '../src/index';
 
-describe('@ariadne/types', () => {
+describe('@ariadnejs/types', () => {
   it('should export Scoping enum', () => {
     expect(Scoping.Local).toBe(0);
     expect(Scoping.Hoisted).toBe(1);


### PR DESCRIPTION
## Summary

- Changed npm package scope from  to 
- The  organization on npm is already taken and appears to be empty/inactive
- Using the common convention for JavaScript/TypeScript packages when the ideal name is taken

## Breaking Changes

This is a **breaking change** that requires all consumers to update their imports and dependencies:

**Before:**
```json
{
  "dependencies": {
    "@ariadne/core": "^0.5.9",
    "@ariadne/types": "^0.5.9"
  }
}
```

**After:**
```json
{
  "dependencies": {
    "@ariadnejs/core": "^1.0.0",
    "@ariadnejs/types": "^1.0.0"
  }
}
```

## Changes

- Updated all package.json files to use @ariadnejs scope
- Updated all internal imports and dependencies
- Updated GitHub Actions workflow references
- Updated documentation and examples
- Added changeset for major version bump

## Test Plan

- [x] npm install works
- [x] npm run build succeeds
- [ ] Tests pass
- [ ] Publishing to npm will work (can't test until merged)