### PR TITLE
fix: prebuild workflow for monorepo structure

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -79,7 +79,7 @@ jobs:
         
       - name: Rebuild native modules for target
         run: |
-          npm rebuild --build-from-source
+          cd packages/core && npm rebuild --build-from-source
         env:
           npm_config_arch: ${{ matrix.arch }}
           npm_config_target_arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Summary

Fixes the prebuild step in the release workflow that was failing after the monorepo migration.

## Problem

The prebuild job was trying to run `npm rebuild` in the root directory, but the native modules (tree-sitter packages) are now located in `packages/core`.

## Solution

Changed the prebuild step to run in the correct directory:
```bash
cd packages/core && npm rebuild --build-from-source
```

This ensures the tree-sitter native modules are rebuilt correctly for each platform during the release process.