### PR TITLE
chore: test prebuild workflow

### DIFF
--- a/.changeset/test-prebuild.md
+++ b/.changeset/test-prebuild.md
@@ -1,0 +1,6 @@
+---
+"@ariadnejs/core": patch
+"@ariadnejs/types": patch
+---
+
+Testing prebuild workflow after monorepo fixes


### PR DESCRIPTION
Testing that the prebuild workflow works correctly after the monorepo fixes.

This will bump versions to 0.5.11 and verify the full release pipeline including prebuild binaries.