### PR TITLE
fix: prebuild workflow for monorepo structure

### DIFF
--- a/.changeset/fix-prebuild-path.md
+++ b/.changeset/fix-prebuild-path.md
@@ -1,0 +1,6 @@
+---
+"@ariadnejs/core": patch
+"@ariadnejs/types": patch
+---
+
+Fix prebuild workflow to use correct working directory for monorepo structure

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -77,9 +77,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
         
+      - name: Build TypeScript packages
+        run: npm run build
+        
       - name: Rebuild native modules for target
+        working-directory: packages/core
         run: |
-          cd packages/core && npm rebuild --build-from-source
+          npm rebuild --build-from-source
         env:
           npm_config_arch: ${{ matrix.arch }}
           npm_config_target_arch: ${{ matrix.arch }}
@@ -87,6 +91,7 @@ jobs:
           npm_config_runtime: node
           npm_config_cache: ~/.npm
           npm_config_build_from_source: true
+          CXXFLAGS: "-std=c++14"
           
       - name: Package prebuilt binaries
         shell: bash


### PR DESCRIPTION
## Summary

Comprehensive fixes for the prebuild workflow to work correctly with the monorepo structure.

## Problem

The prebuild job was failing with C++ compilation errors when trying to rebuild tree-sitter modules. Multiple issues:
1. Working directory context wasn't properly set
2. C++ compiler was defaulting to C++98 mode, causing errors with node-addon-api
3. TypeScript packages weren't built before native module rebuild

## Solution

1. Use `working-directory` instead of `cd` for better GitHub Actions context
2. Add `CXXFLAGS="-std=c++14"` to fix C++ compilation errors
3. Build TypeScript packages first with `npm run build`
4. Include changeset to test the full release pipeline

## Test Plan

This PR includes a changeset that will:
1. Bump versions to 0.5.12
2. Trigger the full release pipeline including prebuild
3. Verify prebuilt binaries are created for all platforms