### PR TITLE
fix: prevent native module hoisting in monorepo

### DIFF
--- a/.changeset/fix-prebuild-hoisting.md
+++ b/.changeset/fix-prebuild-hoisting.md
@@ -1,0 +1,6 @@
+---
+"@ariadnejs/core": patch
+"@ariadnejs/types": patch
+---
+
+Prevent tree-sitter packages from being hoisted to fix prebuild workflow

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+public-hoist-pattern[]=*types*
+public-hoist-pattern[]=*js-yaml*
+public-hoist-pattern[]=*tar*


### PR DESCRIPTION
## Summary

Fixes the prebuild workflow by preventing tree-sitter native modules from being hoisted to the root node_modules.

## Problem

The prebuild job was failing because npm workspaces was hoisting the tree-sitter packages to the root node_modules directory. When the workflow tried to rebuild native modules in `packages/core`, it was looking in the wrong location.

## Solution

Added an `.npmrc` file that controls package hoisting:
- Only non-native packages (types, js-yaml, tar) are hoisted to root
- Tree-sitter packages remain in `packages/core/node_modules`
- This ensures `npm rebuild` runs in the correct directory

## Test Plan

This PR includes a changeset that will:
1. Bump versions to 0.5.13
2. Test that the prebuild workflow can now correctly rebuild native modules
3. Verify prebuilt binaries are created for all platforms