### PR TITLE
fix: prebuild workflow with C++17 and workspace-specific installation

### DIFF
--- a/.changeset/fix-prebuild-cpp17.md
+++ b/.changeset/fix-prebuild-cpp17.md
@@ -1,0 +1,6 @@
+---
+"@ariadnejs/core": patch
+"@ariadnejs/types": patch
+---
+
+Fix prebuild workflow with C++17 and direct package installation

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -74,15 +74,13 @@ jobs:
         with:
           node-version: '20'
           
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies in workspace root
+        run: npm ci --ignore-scripts
         
-      - name: Build TypeScript packages
-        run: npm run build
-        
-      - name: Rebuild native modules for target
+      - name: Install and rebuild in core package
         working-directory: packages/core
         run: |
+          npm ci
           npm rebuild --build-from-source
         env:
           npm_config_arch: ${{ matrix.arch }}
@@ -91,7 +89,7 @@ jobs:
           npm_config_runtime: node
           npm_config_cache: ~/.npm
           npm_config_build_from_source: true
-          CXXFLAGS: "-std=c++14"
+          CXXFLAGS: "-std=c++17"
           
       - name: Package prebuilt binaries
         shell: bash

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-public-hoist-pattern[]=*types*
-public-hoist-pattern[]=*js-yaml*
-public-hoist-pattern[]=*tar*
+public-hoist-pattern[]=*
+public-hoist-pattern[]='!tree-sitter*'


### PR DESCRIPTION
## Summary

Fixes the prebuild workflow by using C++17 and installing directly in the packages/core directory.

## Problem

The prebuild was failing because:
1. Tree-sitter native modules require C++17 features
2. npm workspaces was hoisting modules to the root, causing rebuild to look in the wrong location

## Solution

1. **Update CXXFLAGS to use C++17** - fixes compilation errors with modern C++ features
2. **Install with --ignore-scripts** - prevents initial build attempts in wrong location  
3. **Run npm ci directly in packages/core** - ensures native modules are installed in the correct location
4. **Update .npmrc** - attempt to prevent tree-sitter hoisting (belt and suspenders approach)

## Test Plan

This PR includes a changeset that will:
1. Bump versions to 0.5.14
2. Test the prebuild workflow with these fixes
3. Verify prebuilt binaries are created successfully