### PR TITLE
refactor(mcp): replace SQLite analytics with JSONL files

### DIFF
--- a/.claude/skills/mcp-analytics/SKILL.md
+++ b/.claude/skills/mcp-analytics/SKILL.md
@@ -5,7 +5,7 @@ user_invocable: false
 
 # MCP Analytics
 
-Query Ariadne MCP tool usage analytics from the SQLite database.
+Query Ariadne MCP tool usage analytics from JSONL files.
 
 ## When to Use
 
@@ -31,7 +31,7 @@ For per-session detail:
 npx tsx packages/mcp/src/scripts/ariadne_analytics.ts --session <session-id>
 ```
 
-The DB path defaults to `~/.ariadne/analytics.db`. Override with `ARIADNE_ANALYTICS_DB` env var.
+The data directory defaults to `~/.ariadne/analytics/`. Override with `ARIADNE_ANALYTICS_DIR` env var.
 
 ## Interpreting Results
 
@@ -41,3 +41,14 @@ The DB path defaults to `~/.ariadne/analytics.db`. Override with `ARIADNE_ANALYT
 - **Recent sessions**: Last N sessions with client info, project path, and call count
 
 High failure counts or increasing average durations indicate performance issues worth investigating.
+
+## Optional: SQLite Import
+
+The JSONL files can be converted to CSV and imported into SQLite for ad-hoc queries:
+
+```bash
+cd ~/.ariadne/analytics
+jq -r '[.session_id, .started_at, .project_path, .client_name, .client_version] | @csv' sessions.jsonl > sessions.csv
+jq -r '[.session_id, .tool_name, .called_at, .duration_ms, .success, .error_message, .arguments, .request_id, .tool_use_id] | @csv' tool_calls.jsonl > tool_calls.csv
+sqlite3 analytics.db ".mode csv" ".import sessions.csv sessions" ".import tool_calls.csv tool_calls"
+```

--- a/.claude/skills/self-repair-pipeline/SKILL.md
+++ b/.claude/skills/self-repair-pipeline/SKILL.md
@@ -8,7 +8,7 @@ hooks:
   Stop:
     - hooks:
         - type: command
-          command: "pnpm exec tsx \"$CLAUDE_PROJECT_DIR/.claude/skills/self-repair-pipeline/scripts/triage_loop_stop.ts\""
+          command: 'pnpm exec tsx "$CLAUDE_PROJECT_DIR/.claude/skills/self-repair-pipeline/scripts/triage_loop_stop.ts"'
           timeout: 30
 ---
 
@@ -18,13 +18,13 @@ Triage pipeline for entry point analysis: detect false positives, classify root 
 
 ## Pipeline Overview
 
-| Phase | Script / Agent | Purpose |
-| ----- | -------------- | ------- |
-| 1. Detect | `scripts/detect_entrypoints.ts` | Run entry point detection |
-| 2. Prepare | `scripts/prepare_triage.ts` | Classify against known-entrypoints registry, build triage state |
-| 3. Triage Loop | triage-investigator, triage-aggregator, triage-rule-reviewer | Investigate pending entries, aggregate results, review for patterns |
-| 4. Fix Planning | fix-planner, plan-synthesizer, plan-reviewer, task-writer | Generate competing fix plans, synthesize, review, create tasks |
-| 5. Finalize | `scripts/finalize_triage.ts` | Save results, update registry |
+| Phase           | Script / Agent                                               | Purpose                                                             |
+| --------------- | ------------------------------------------------------------ | ------------------------------------------------------------------- |
+| 1. Detect       | `scripts/detect_entrypoints.ts`                              | Run entry point detection                                           |
+| 2. Prepare      | `scripts/prepare_triage.ts`                                  | Classify against known-entrypoints registry, build triage state     |
+| 3. Triage Loop  | triage-investigator, triage-aggregator, triage-rule-reviewer | Investigate pending entries, aggregate results, review for patterns |
+| 4. Fix Planning | fix-planner, plan-synthesizer, plan-reviewer, task-writer    | Generate competing fix plans, synthesize, review, create tasks      |
+| 5. Finalize     | `scripts/finalize_triage.ts`                                 | Save results, update registry                                       |
 
 ## Analysis Target
 
@@ -32,21 +32,21 @@ Triage pipeline for entry point analysis: detect false positives, classify root 
 
 Resolve the analysis target from the user's input using this routing table:
 
-| Input pattern | Example | Action |
-| ------------- | ------- | ------ |
-| Empty or blank | `/self-repair-pipeline` | List available configs below, ask user what to analyze |
-| Config name | `core`, `mcp`, `types`, `projections` | Use `--config .claude/skills/self-repair-pipeline/project_configs/{name}.json` |
-| Absolute or relative directory path | `/Users/chuck/workspace/some-repo`, `../other-repo` | Use `--path <path>` |
-| `owner/repo` or GitHub URL | `anthropics/sdk-python`, `https://github.com/owner/repo` | Use `--github <value>` |
-| Natural language | "analyze the core package" | Interpret intent and map to one of the above |
+| Input pattern                       | Example                                                  | Action                                                                         |
+| ----------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Empty or blank                      | `/self-repair-pipeline`                                  | List available configs below, ask user what to analyze                         |
+| Config name                         | `core`, `mcp`, `types`, `projections`                    | Use `--config .claude/skills/self-repair-pipeline/project_configs/{name}.json` |
+| Absolute or relative directory path | `/Users/chuck/workspace/some-repo`, `../other-repo`      | Use `--path <path>`                                                            |
+| `owner/repo` or GitHub URL          | `anthropics/sdk-python`, `https://github.com/owner/repo` | Use `--github <value>`                                                         |
+| Natural language                    | "analyze the core package"                               | Interpret intent and map to one of the above                                   |
 
 Available project configs:
 
-| Config name | Config path |
-| ----------- | ----------- |
-| `core` | `project_configs/core.json` |
-| `mcp` | `project_configs/mcp.json` |
-| `types` | `project_configs/types.json` |
+| Config name   | Config path                        |
+| ------------- | ---------------------------------- |
+| `core`        | `project_configs/core.json`        |
+| `mcp`         | `project_configs/mcp.json`         |
+| `types`       | `project_configs/types.json`       |
 | `projections` | `project_configs/projections.json` |
 
 If no arguments are provided or the input is ambiguous, **ask the user** before proceeding.
@@ -57,14 +57,14 @@ If no arguments are provided or the input is ambiguous, **ask the user** before 
 
 ## State and Output Locations
 
-| File | Purpose |
-| ---- | ------- |
-| `triage_state/{project}_triage.json` | Active triage state (phases, entries, results) |
-| `triage_state/results/{entry_index}.json` | Per-entry triage result files (written by sub-agents) |
-| `triage_state/fix_plans/{group_id}/` | Fix plans, synthesis, and reviews per group |
-| `analysis_output/{project}/` | Project-scoped timestamped analysis and triage result files |
-| `known_entrypoints/{project}.json` | Known-entrypoints registry (persists across runs) |
-| `triage_patterns.json` | Extracted classification patterns from meta-review |
+| File                                      | Purpose                                                     |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| `triage_state/{project}_triage.json`      | Active triage state (phases, entries, results)              |
+| `triage_state/results/{entry_index}.json` | Per-entry triage result files (written by sub-agents)       |
+| `triage_state/fix_plans/{group_id}/`      | Fix plans, synthesis, and reviews per group                 |
+| `analysis_output/{project}/`              | Project-scoped timestamped analysis and triage result files |
+| `known_entrypoints/{project}.json`        | Known-entrypoints registry (persists across runs)           |
+| `triage_patterns.json`                    | Extracted classification patterns from meta-review          |
 
 All paths above are relative to `.claude/skills/self-repair-pipeline/`.
 
@@ -120,12 +120,12 @@ For each pending entry in the state file:
 
 1. Read the entry's `diagnosis` field to select the prompt template:
 
-   | Diagnosis | Template | Focus |
-   | --------- | -------- | ----- |
-   | `callers-not-in-registry` | `templates/prompt_callers_not_in_registry.md` | File coverage gap investigation |
-   | `callers-in-registry-unresolved` | `templates/prompt_resolution_failure.md` | Resolution failure pattern identification |
-   | `callers-in-registry-wrong-target` | `templates/prompt_wrong_target.md` | Wrong resolution target analysis |
-   | All other diagnoses | `templates/prompt_generic.md` | Broad investigation |
+   | Diagnosis                          | Template                                      | Focus                                     |
+   | ---------------------------------- | --------------------------------------------- | ----------------------------------------- |
+   | `callers-not-in-registry`          | `templates/prompt_callers_not_in_registry.md` | File coverage gap investigation           |
+   | `callers-in-registry-unresolved`   | `templates/prompt_resolution_failure.md`      | Resolution failure pattern identification |
+   | `callers-in-registry-wrong-target` | `templates/prompt_wrong_target.md`            | Wrong resolution target analysis          |
+   | All other diagnoses                | `templates/prompt_generic.md`                 | Broad investigation                       |
 
 2. Read the template and substitute `{{entry.*}}` placeholders with values from the entry
 3. Launch a **triage-investigator** sub-agent with `run_in_background: true`. Include `output_path` = `triage_state/results/{entry.entry_index}.json` in the prompt
@@ -215,16 +215,16 @@ Finalization:
 
 All library modules live under `src/`:
 
-| Module | Purpose |
-| ------ | ------- |
-| `extract_entry_points.ts` | Shared extraction with enriched metadata + diagnostics |
-| `classify_entrypoints.ts` | Deterministic rule-based classification (no LLM) |
-| `known_entrypoints.ts` | Known-entrypoints registry I/O and matching |
-| `build_triage_entries.ts` | Build triage entries from classification results |
-| `build_finalization_output.ts` | Build finalization output from completed state |
-| `types.ts` | Shared type definitions (`EnrichedFunctionEntry`, `EntryPointDiagnostics`, etc.) |
-| `triage_state_types.ts` | Triage state machine types |
-| `analysis_io.ts` | Analysis file lookup, JSON I/O |
+| Module                         | Purpose                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------- |
+| `extract_entry_points.ts`      | Shared extraction with enriched metadata + diagnostics                           |
+| `classify_entrypoints.ts`      | Deterministic rule-based classification (no LLM)                                 |
+| `known_entrypoints.ts`         | Known-entrypoints registry I/O and matching                                      |
+| `build_triage_entries.ts`      | Build triage entries from classification results                                 |
+| `build_finalization_output.ts` | Build finalization output from completed state                                   |
+| `types.ts`                     | Shared type definitions (`EnrichedFunctionEntry`, `EntryPointDiagnostics`, etc.) |
+| `triage_state_types.ts`        | Triage state machine types                                                       |
+| `analysis_io.ts`               | Analysis file lookup, JSON I/O                                                   |
 
 ## Reference
 
@@ -234,12 +234,12 @@ All library modules live under `src/`:
 
 ## Sub-Agents
 
-| Agent | Model | Purpose |
-| ----- | ----- | ------- |
-| triage-investigator | sonnet | Investigate a single pending entry using diagnosis-specific prompt template |
-| triage-aggregator | sonnet | Review all entry results, group by root cause, merge duplicates |
+| Agent                | Model  | Purpose                                                                     |
+| -------------------- | ------ | --------------------------------------------------------------------------- |
+| triage-investigator  | sonnet | Investigate a single pending entry using diagnosis-specific prompt template |
+| triage-aggregator    | sonnet | Review all entry results, group by root cause, merge duplicates             |
 | triage-rule-reviewer | sonnet | Analyze false-positive patterns, propose deterministic classification rules |
-| fix-planner | sonnet | Generate one independent fix proposal for a false-positive group |
-| plan-synthesizer | opus | Synthesize 5 competing plans into a unified fix approach |
-| plan-reviewer | sonnet | Review synthesized plan from one specific angle |
-| task-writer | sonnet | Create a backlog task from synthesis + reviews using the task template |
+| fix-planner          | sonnet | Generate one independent fix proposal for a false-positive group            |
+| plan-synthesizer     | opus   | Synthesize 5 competing plans into a unified fix approach                    |
+| plan-reviewer        | sonnet | Review synthesized plan from one specific angle                             |
+| task-writer          | sonnet | Create a backlog task from synthesis + reviews using the task template      |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3",
       "esbuild",
       "tree-sitter",
       "tree-sitter-javascript",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -53,12 +53,10 @@
     "@ariadnejs/core": "workspace:*",
     "@ariadnejs/types": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "better-sqlite3": "^11.0.0",
     "chokidar": "^3.6.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.0.0",
     "@vitest/ui": "^3.2.4",
     "vitest": "^3.2.4"

--- a/packages/mcp/src/analytics/analytics.test.ts
+++ b/packages/mcp/src/analytics/analytics.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import Database from "better-sqlite3";
 import * as os from "os";
 import * as path from "path";
-import * as node_fs from "fs";
+import * as fs from "fs";
 import {
   init_analytics,
   is_analytics_enabled,
@@ -11,117 +10,90 @@ import {
   close_analytics,
 } from "./analytics";
 
-// Mock readFileSync so is_analytics_enabled tests can control config file reads.
-// The real implementation is preserved for all other fs functions.
-const mock_read_file_sync = vi.hoisted(() => vi.fn());
-vi.mock("fs", async (import_original) => {
-  const actual = await import_original<typeof import("fs")>();
-  return { ...actual, readFileSync: mock_read_file_sync };
-});
-
 // Suppress logger output during tests
 vi.mock("../logger", () => ({
   log_info: vi.fn(),
   log_warn: vi.fn(),
 }));
 
-function open_readonly(db_path: string): Database.Database {
-  return new Database(db_path, { readonly: true });
+function read_jsonl<T>(file_path: string): T[] {
+  const content = fs.readFileSync(file_path, "utf-8");
+  return content
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
 }
 
 describe("analytics", () => {
-  let db_path: string;
+  let analytics_dir: string;
   let sid: string;
   let tmp_dir: string;
 
   beforeEach(() => {
-    tmp_dir = node_fs.mkdtempSync(
-      path.join(os.tmpdir(), "ariadne-analytics-test-")
+    tmp_dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ariadne-analytics-test-"),
     );
-    db_path = path.join(tmp_dir, "test.db");
+    analytics_dir = path.join(tmp_dir, "analytics");
   });
 
   afterEach(() => {
     close_analytics();
-    node_fs.rmSync(tmp_dir, { recursive: true, force: true });
+    fs.rmSync(tmp_dir, { recursive: true, force: true });
   });
 
   describe("init_analytics", () => {
-    it("creates tables and session row", () => {
-      sid = init_analytics("/test/project", db_path);
+    it("creates analytics directory and returns session id", () => {
+      sid = init_analytics("/test/project", analytics_dir);
 
       expect(sid).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
+      expect(fs.existsSync(analytics_dir)).toEqual(true);
+    });
 
-      const reader = open_readonly(db_path);
-      const session = reader
-        .prepare("SELECT * FROM sessions WHERE session_id = ?")
-        .get(sid) as {
+    it("writes session to sessions.jsonl on close", () => {
+      sid = init_analytics("/test/project", analytics_dir);
+      close_analytics();
+
+      const sessions = read_jsonl<{
         session_id: string;
         started_at: string;
         project_path: string;
         client_name: string | null;
         client_version: string | null;
-      };
+      }>(path.join(analytics_dir, "sessions.jsonl"));
 
-      expect(session.project_path).toEqual("/test/project");
-      expect(session.client_name).toBeNull();
-      expect(session.client_version).toBeNull();
-      expect(session.started_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-      reader.close();
-    });
-
-    it("creates tool_calls table with correct schema", () => {
-      init_analytics("/test/project", db_path);
-
-      const reader = open_readonly(db_path);
-      const columns = reader
-        .prepare("PRAGMA table_info(tool_calls)")
-        .all() as { name: string }[];
-      const column_names = columns.map((c) => c.name);
-
-      expect(column_names).toEqual([
-        "id",
-        "session_id",
-        "tool_name",
-        "called_at",
-        "duration_ms",
-        "success",
-        "error_message",
-        "arguments",
-        "request_id",
-        "tool_use_id",
-      ]);
-      reader.close();
+      expect(sessions.length).toEqual(1);
+      expect(sessions[0].session_id).toEqual(sid);
+      expect(sessions[0].project_path).toEqual("/test/project");
+      expect(sessions[0].client_name).toBeNull();
+      expect(sessions[0].client_version).toBeNull();
+      expect(sessions[0].started_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
   });
 
   describe("record_session_client_info", () => {
     beforeEach(() => {
-      sid = init_analytics("/test/project", db_path);
+      sid = init_analytics("/test/project", analytics_dir);
     });
 
-    it("updates client info on session", () => {
+    it("includes client info in session record on close", () => {
       record_session_client_info("claude-code", "1.0.22");
+      close_analytics();
 
-      const reader = open_readonly(db_path);
-      const session = reader
-        .prepare("SELECT * FROM sessions WHERE session_id = ?")
-        .get(sid) as {
+      const sessions = read_jsonl<{
         client_name: string;
         client_version: string;
-      };
+      }>(path.join(analytics_dir, "sessions.jsonl"));
 
-      expect(session.client_name).toEqual("claude-code");
-      expect(session.client_version).toEqual("1.0.22");
-      reader.close();
+      expect(sessions[0].client_name).toEqual("claude-code");
+      expect(sessions[0].client_version).toEqual("1.0.22");
     });
   });
 
   describe("record_tool_call", () => {
     beforeEach(() => {
-      sid = init_analytics("/test/project", db_path);
+      sid = init_analytics("/test/project", analytics_dir);
     });
 
     it("writes correct data including request_id and tool_use_id", () => {
@@ -134,33 +106,31 @@ describe("analytics", () => {
         tool_use_id: "toolu_01abc123",
       });
 
-      const reader = open_readonly(db_path);
-      const row = reader
-        .prepare("SELECT * FROM tool_calls WHERE session_id = ?")
-        .get(sid) as {
+      const rows = read_jsonl<{
         session_id: string;
         tool_name: string;
         called_at: string;
         duration_ms: number;
-        success: number;
+        success: boolean;
         error_message: string | null;
-        arguments: string;
+        arguments: Record<string, unknown>;
         request_id: string;
         tool_use_id: string;
-      };
+      }>(path.join(analytics_dir, "tool_calls.jsonl"));
 
-      expect(row.tool_name).toEqual("list_entrypoints");
-      expect(row.duration_ms).toEqual(450);
-      expect(row.success).toEqual(1);
-      expect(row.error_message).toBeNull();
-      expect(JSON.parse(row.arguments)).toEqual({ files: ["src/main.ts"] });
-      expect(row.request_id).toEqual("req-123");
-      expect(row.tool_use_id).toEqual("toolu_01abc123");
-      expect(row.called_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-      reader.close();
+      expect(rows.length).toEqual(1);
+      expect(rows[0].session_id).toEqual(sid);
+      expect(rows[0].tool_name).toEqual("list_entrypoints");
+      expect(rows[0].duration_ms).toEqual(450);
+      expect(rows[0].success).toEqual(true);
+      expect(rows[0].error_message).toBeNull();
+      expect(rows[0].arguments).toEqual({ files: ["src/main.ts"] });
+      expect(rows[0].request_id).toEqual("req-123");
+      expect(rows[0].tool_use_id).toEqual("toolu_01abc123");
+      expect(rows[0].called_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
 
-    it("stores NULL when tool_use_id is omitted", () => {
+    it("stores null when tool_use_id is omitted", () => {
       record_tool_call({
         tool_name: "list_entrypoints",
         arguments: {},
@@ -169,13 +139,11 @@ describe("analytics", () => {
         request_id: "req-789",
       });
 
-      const reader = open_readonly(db_path);
-      const row = reader
-        .prepare("SELECT tool_use_id FROM tool_calls WHERE session_id = ?")
-        .get(sid) as { tool_use_id: string | null };
+      const rows = read_jsonl<{ tool_use_id: string | null }>(
+        path.join(analytics_dir, "tool_calls.jsonl"),
+      );
 
-      expect(row.tool_use_id).toBeNull();
-      reader.close();
+      expect(rows[0].tool_use_id).toBeNull();
     });
 
     it("records error details on failure", () => {
@@ -188,17 +156,13 @@ describe("analytics", () => {
         request_id: "req-456",
       });
 
-      const reader = open_readonly(db_path);
-      const row = reader
-        .prepare("SELECT * FROM tool_calls WHERE session_id = ?")
-        .get(sid) as {
-        success: number;
+      const rows = read_jsonl<{
+        success: boolean;
         error_message: string;
-      };
+      }>(path.join(analytics_dir, "tool_calls.jsonl"));
 
-      expect(row.success).toEqual(0);
-      expect(row.error_message).toEqual("Symbol not found");
-      reader.close();
+      expect(rows[0].success).toEqual(false);
+      expect(rows[0].error_message).toEqual("Symbol not found");
     });
 
     it("no-ops when not initialized", () => {
@@ -213,30 +177,23 @@ describe("analytics", () => {
       });
     });
 
-    it("never throws even on DB failure", () => {
-      // Close analytics so the internal DB handle is gone, then re-init
-      // with a readonly DB to force a write failure
-      close_analytics();
-      const readonly_db_path = path.join(tmp_dir, "readonly.db");
-      init_analytics("/test/project", readonly_db_path);
+    it("never throws even on write failure", () => {
       close_analytics();
 
-      // Re-open as readonly and try to record — but we need to trick the module.
-      // Instead, just verify that calling record after close doesn't throw.
       expect(() =>
         record_tool_call({
           tool_name: "list_entrypoints",
           arguments: {},
           duration_ms: 100,
           success: true,
-        })
+        }),
       ).not.toThrow();
     });
   });
 
   describe("close_analytics", () => {
     it("makes record_tool_call no-op after close", () => {
-      sid = init_analytics("/test/project", db_path);
+      sid = init_analytics("/test/project", analytics_dir);
       close_analytics();
 
       // Should silently no-op
@@ -247,12 +204,8 @@ describe("analytics", () => {
         success: true,
       });
 
-      const reader = open_readonly(db_path);
-      const row = reader
-        .prepare("SELECT COUNT(*) as count FROM tool_calls")
-        .get() as { count: number };
-      expect(row.count).toEqual(0);
-      reader.close();
+      const tool_calls_path = path.join(analytics_dir, "tool_calls.jsonl");
+      expect(fs.existsSync(tool_calls_path)).toEqual(false);
     });
 
     it("is safe to call when not initialized", () => {
@@ -270,7 +223,6 @@ describe("analytics", () => {
 
     afterEach(() => {
       process.env = original_env;
-      vi.restoreAllMocks();
     });
 
     it("returns true when ARIADNE_ANALYTICS=1 env var is set", () => {
@@ -279,26 +231,36 @@ describe("analytics", () => {
     });
 
     it("returns true when config file has analytics: true", () => {
-      mock_read_file_sync.mockReturnValue(JSON.stringify({ analytics: true }));
+      const config_dir = path.join(tmp_dir, ".ariadne");
+      fs.mkdirSync(config_dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(config_dir, "config.json"),
+        JSON.stringify({ analytics: true }),
+      );
+      process.env.HOME = tmp_dir;
+
       expect(is_analytics_enabled()).toEqual(true);
     });
 
     it("returns false when neither env var nor config is set", () => {
-      mock_read_file_sync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
+      process.env.HOME = tmp_dir;
       expect(is_analytics_enabled()).toEqual(false);
     });
 
     it("returns false when config file does not exist", () => {
-      mock_read_file_sync.mockImplementation(() => {
-        throw new Error("ENOENT: no such file or directory");
-      });
+      process.env.HOME = tmp_dir;
       expect(is_analytics_enabled()).toEqual(false);
     });
 
     it("returns false when config file is malformed JSON", () => {
-      mock_read_file_sync.mockReturnValue("not valid json{{");
+      const config_dir = path.join(tmp_dir, ".ariadne");
+      fs.mkdirSync(config_dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(config_dir, "config.json"),
+        "not valid json{{",
+      );
+      process.env.HOME = tmp_dir;
+
       expect(is_analytics_enabled()).toEqual(false);
     });
   });

--- a/packages/mcp/src/analytics/analytics.ts
+++ b/packages/mcp/src/analytics/analytics.ts
@@ -1,4 +1,3 @@
-import Database from "better-sqlite3";
 import * as crypto from "crypto";
 import * as path from "path";
 import * as fs from "fs";
@@ -14,115 +13,86 @@ export interface ToolCallRecord {
   tool_use_id?: string;
 }
 
-// Module-level singleton state (matches logger.ts pattern)
-let db: Database.Database | null = null;
+let analytics_dir: string | null = null;
 let session_id: string | null = null;
+let started_at: string | null = null;
+let project_path_stored: string | null = null;
+let client_name: string | null = null;
+let client_version: string | null = null;
 
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS sessions (
-  session_id      TEXT PRIMARY KEY,
-  started_at      TEXT NOT NULL,
-  project_path    TEXT NOT NULL,
-  client_name     TEXT,
-  client_version  TEXT
-);
-
-CREATE TABLE IF NOT EXISTS tool_calls (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id    TEXT NOT NULL,
-  tool_name     TEXT NOT NULL,
-  called_at     TEXT NOT NULL,
-  duration_ms   INTEGER NOT NULL,
-  success       INTEGER NOT NULL,
-  error_message TEXT,
-  arguments     TEXT NOT NULL,
-  request_id    TEXT,
-  tool_use_id   TEXT,
-  FOREIGN KEY (session_id) REFERENCES sessions(session_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
-CREATE INDEX IF NOT EXISTS idx_tool_calls_tool_name ON tool_calls(tool_name);
-CREATE INDEX IF NOT EXISTS idx_tool_calls_called_at ON tool_calls(called_at);
-`;
-
-function resolve_db_path(db_path?: string): string {
-  if (db_path) return db_path;
-  if (process.env.ARIADNE_ANALYTICS_DB) return process.env.ARIADNE_ANALYTICS_DB;
+export function resolve_analytics_dir(dir?: string): string {
+  if (dir) return dir;
+  if (process.env.ARIADNE_ANALYTICS_DIR) return process.env.ARIADNE_ANALYTICS_DIR;
   const home = process.env.HOME || process.env.USERPROFILE || "";
-  return path.join(home, ".ariadne", "analytics.db");
+  return path.join(home, ".ariadne", "analytics");
 }
 
-export function init_analytics(project_path: string, db_path?: string): string {
-  const resolved_path = resolve_db_path(db_path);
+export function init_analytics(project_path: string, dir?: string): string {
+  const resolved_dir = resolve_analytics_dir(dir);
 
-  // Create directory if needed (unless in-memory)
-  if (resolved_path !== ":memory:") {
-    const dir = path.dirname(resolved_path);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-  }
+  fs.mkdirSync(resolved_dir, { recursive: true });
 
-  db = new Database(resolved_path);
-  db.pragma("journal_mode = WAL");
-  db.exec(SCHEMA);
-  try { db.exec("ALTER TABLE tool_calls ADD COLUMN tool_use_id TEXT"); } catch { /* exists */ }
-
+  analytics_dir = resolved_dir;
   session_id = crypto.randomUUID();
-  const started_at = new Date().toISOString();
-
-  db.prepare(
-    "INSERT INTO sessions (session_id, started_at, project_path) VALUES (?, ?, ?)"
-  ).run(session_id, started_at, project_path);
+  started_at = new Date().toISOString();
+  project_path_stored = project_path;
+  client_name = null;
+  client_version = null;
 
   log_info(`Analytics initialized (session: ${session_id})`);
   return session_id;
 }
 
 export function record_session_client_info(
-  client_name: string,
-  client_version: string
+  name: string,
+  version: string,
 ): void {
-  if (!db || !session_id) return;
-  try {
-    db.prepare(
-      "UPDATE sessions SET client_name = ?, client_version = ? WHERE session_id = ?"
-    ).run(client_name, client_version, session_id);
-  } catch (error) {
-    log_warn(`Failed to record client info: ${error}`);
-  }
+  if (!analytics_dir || !session_id) return;
+  client_name = name;
+  client_version = version;
 }
 
 export function record_tool_call(record: ToolCallRecord): void {
-  if (!db || !session_id) return;
+  if (!analytics_dir || !session_id) return;
   try {
-    const called_at = new Date().toISOString();
-    db.prepare(
-      `INSERT INTO tool_calls (session_id, tool_name, called_at, duration_ms, success, error_message, arguments, request_id, tool_use_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
+    const line = JSON.stringify({
       session_id,
-      record.tool_name,
-      called_at,
-      record.duration_ms,
-      record.success ? 1 : 0,
-      record.error_message ?? null,
-      JSON.stringify(record.arguments),
-      record.request_id ?? null,
-      record.tool_use_id ?? null
-    );
+      tool_name: record.tool_name,
+      called_at: new Date().toISOString(),
+      duration_ms: record.duration_ms,
+      success: record.success,
+      error_message: record.error_message ?? null,
+      arguments: record.arguments,
+      request_id: record.request_id ?? null,
+      tool_use_id: record.tool_use_id ?? null,
+    });
+    fs.appendFileSync(path.join(analytics_dir, "tool_calls.jsonl"), line + "\n");
   } catch (error) {
     log_warn(`Failed to record tool call: ${error}`);
   }
 }
 
 export function close_analytics(): void {
-  if (db) {
-    db.close();
-    db = null;
+  if (analytics_dir && session_id) {
+    try {
+      const line = JSON.stringify({
+        session_id,
+        started_at,
+        project_path: project_path_stored,
+        client_name,
+        client_version,
+      });
+      fs.appendFileSync(path.join(analytics_dir, "sessions.jsonl"), line + "\n");
+    } catch (error) {
+      log_warn(`Failed to write session record: ${error}`);
+    }
   }
+  analytics_dir = null;
   session_id = null;
+  started_at = null;
+  project_path_stored = null;
+  client_name = null;
+  client_version = null;
 }
 
 export function is_analytics_enabled(): boolean {

--- a/packages/mcp/src/analytics/query_stats.test.ts
+++ b/packages/mcp/src/analytics/query_stats.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import Database from "better-sqlite3";
+import { describe, it, expect } from "vitest";
 import {
   calls_per_tool,
   calls_in_range,
@@ -8,83 +7,96 @@ import {
   ToolCallSummary,
   SessionSummary,
   ToolCallDetail,
+  SessionRow,
+  ToolCallRow,
 } from "./query_stats";
 
-const SCHEMA = `
-CREATE TABLE sessions (
-  session_id      TEXT PRIMARY KEY,
-  started_at      TEXT NOT NULL,
-  project_path    TEXT NOT NULL,
-  client_name     TEXT,
-  client_version  TEXT
-);
+const SESSIONS: SessionRow[] = [
+  {
+    session_id: "s1",
+    started_at: "2026-02-17T10:00:00.000Z",
+    project_path: "/project-a",
+    client_name: "claude-code",
+    client_version: "1.0.22",
+  },
+  {
+    session_id: "s2",
+    started_at: "2026-02-16T14:00:00.000Z",
+    project_path: "/project-b",
+    client_name: "claude-code",
+    client_version: "1.0.21",
+  },
+  {
+    session_id: "s3",
+    started_at: "2026-02-15T08:00:00.000Z",
+    project_path: "/project-a",
+    client_name: null,
+    client_version: null,
+  },
+];
 
-CREATE TABLE tool_calls (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_id    TEXT NOT NULL,
-  tool_name     TEXT NOT NULL,
-  called_at     TEXT NOT NULL,
-  duration_ms   INTEGER NOT NULL,
-  success       INTEGER NOT NULL,
-  error_message TEXT,
-  arguments     TEXT NOT NULL,
-  request_id    TEXT,
-  tool_use_id   TEXT,
-  FOREIGN KEY (session_id) REFERENCES sessions(session_id)
-);
-
-CREATE INDEX idx_tool_calls_session ON tool_calls(session_id);
-CREATE INDEX idx_tool_calls_tool_name ON tool_calls(tool_name);
-CREATE INDEX idx_tool_calls_called_at ON tool_calls(called_at);
-`;
-
-function seed_db(db: Database.Database): void {
-  db.exec(SCHEMA);
-
-  // Insert sessions
-  db.prepare(
-    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)"
-  ).run("s1", "2026-02-17T10:00:00.000Z", "/project-a", "claude-code", "1.0.22");
-
-  db.prepare(
-    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)"
-  ).run("s2", "2026-02-16T14:00:00.000Z", "/project-b", "claude-code", "1.0.21");
-
-  db.prepare(
-    "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)"
-  ).run("s3", "2026-02-15T08:00:00.000Z", "/project-a", null, null);
-
-  // Insert tool calls for s1
-  const insert_call = db.prepare(
-    "INSERT INTO tool_calls (session_id, tool_name, called_at, duration_ms, success, error_message, arguments, request_id, tool_use_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
-  );
-
-  insert_call.run("s1", "list_entrypoints", "2026-02-17T10:01:00.000Z", 400, 1, null, "{\"files\":[\"a.ts\"]}", "r1", "toolu_abc1");
-  insert_call.run("s1", "list_entrypoints", "2026-02-17T10:02:00.000Z", 500, 1, null, "{}", "r2", null);
-  insert_call.run("s1", "show_call_graph_neighborhood", "2026-02-17T10:03:00.000Z", 200, 1, null, "{\"symbol_ref\":\"a:1#f\"}", "r3", "toolu_abc3");
-  insert_call.run("s1", "list_entrypoints", "2026-02-17T10:04:00.000Z", 100, 0, "Timeout", "{}", "r4", null);
-
-  // Insert tool calls for s2
-  insert_call.run("s2", "show_call_graph_neighborhood", "2026-02-16T14:01:00.000Z", 300, 1, null, "{\"symbol_ref\":\"b:2#g\"}", "r5", "toolu_abc5");
-
-  // s3 has no tool calls
-}
+const TOOL_CALLS: ToolCallRow[] = [
+  {
+    session_id: "s1",
+    tool_name: "list_entrypoints",
+    called_at: "2026-02-17T10:01:00.000Z",
+    duration_ms: 400,
+    success: true,
+    error_message: null,
+    arguments: { files: ["a.ts"] },
+    request_id: "r1",
+    tool_use_id: "toolu_abc1",
+  },
+  {
+    session_id: "s1",
+    tool_name: "list_entrypoints",
+    called_at: "2026-02-17T10:02:00.000Z",
+    duration_ms: 500,
+    success: true,
+    error_message: null,
+    arguments: {},
+    request_id: "r2",
+    tool_use_id: null,
+  },
+  {
+    session_id: "s1",
+    tool_name: "show_call_graph_neighborhood",
+    called_at: "2026-02-17T10:03:00.000Z",
+    duration_ms: 200,
+    success: true,
+    error_message: null,
+    arguments: { symbol_ref: "a:1#f" },
+    request_id: "r3",
+    tool_use_id: "toolu_abc3",
+  },
+  {
+    session_id: "s1",
+    tool_name: "list_entrypoints",
+    called_at: "2026-02-17T10:04:00.000Z",
+    duration_ms: 100,
+    success: false,
+    error_message: "Timeout",
+    arguments: {},
+    request_id: "r4",
+    tool_use_id: null,
+  },
+  {
+    session_id: "s2",
+    tool_name: "show_call_graph_neighborhood",
+    called_at: "2026-02-16T14:01:00.000Z",
+    duration_ms: 300,
+    success: true,
+    error_message: null,
+    arguments: { symbol_ref: "b:2#g" },
+    request_id: "r5",
+    tool_use_id: "toolu_abc5",
+  },
+];
 
 describe("query_stats", () => {
-  let db: Database.Database;
-
-  beforeEach(() => {
-    db = new Database(":memory:");
-    seed_db(db);
-  });
-
-  afterEach(() => {
-    db.close();
-  });
-
   describe("calls_per_tool", () => {
     it("returns correct aggregates per tool", () => {
-      const result = calls_per_tool(db);
+      const result = calls_per_tool(TOOL_CALLS);
 
       const expected: ToolCallSummary[] = [
         {
@@ -106,21 +118,17 @@ describe("query_stats", () => {
       expect(result).toEqual(expected);
     });
 
-    it("returns empty array for empty DB", () => {
-      const empty_db = new Database(":memory:");
-      empty_db.exec(SCHEMA);
-
-      expect(calls_per_tool(empty_db)).toEqual([]);
-      empty_db.close();
+    it("returns empty array for empty input", () => {
+      expect(calls_per_tool([])).toEqual([]);
     });
   });
 
   describe("calls_in_range", () => {
     it("filters by date range correctly", () => {
       const result = calls_in_range(
-        db,
+        TOOL_CALLS,
         "2026-02-17T00:00:00.000Z",
-        "2026-02-17T23:59:59.999Z"
+        "2026-02-17T23:59:59.999Z",
       );
 
       const expected: ToolCallSummary[] = [
@@ -145,9 +153,9 @@ describe("query_stats", () => {
 
     it("returns empty array when no calls in range", () => {
       const result = calls_in_range(
-        db,
+        TOOL_CALLS,
         "2026-01-01T00:00:00.000Z",
-        "2026-01-01T23:59:59.999Z"
+        "2026-01-01T23:59:59.999Z",
       );
 
       expect(result).toEqual([]);
@@ -156,7 +164,7 @@ describe("query_stats", () => {
 
   describe("recent_sessions", () => {
     it("returns sessions with call counts ordered by date desc", () => {
-      const result = recent_sessions(db, 3);
+      const result = recent_sessions(SESSIONS, TOOL_CALLS, 3);
 
       const expected: SessionSummary[] = [
         {
@@ -189,13 +197,13 @@ describe("query_stats", () => {
     });
 
     it("respects limit parameter", () => {
-      const result = recent_sessions(db, 1);
+      const result = recent_sessions(SESSIONS, TOOL_CALLS, 1);
       expect(result.length).toEqual(1);
       expect(result[0].session_id).toEqual("s1");
     });
 
     it("includes client info in session summaries", () => {
-      const result = recent_sessions(db, 1);
+      const result = recent_sessions(SESSIONS, TOOL_CALLS, 1);
       expect(result[0].client_name).toEqual("claude-code");
       expect(result[0].client_version).toEqual("1.0.22");
     });
@@ -203,11 +211,10 @@ describe("query_stats", () => {
 
   describe("session_detail", () => {
     it("returns all calls for a specific session", () => {
-      const result = session_detail(db, "s1");
+      const result = session_detail(TOOL_CALLS, "s1");
 
       const expected: ToolCallDetail[] = [
         {
-          id: 1,
           tool_name: "list_entrypoints",
           called_at: "2026-02-17T10:01:00.000Z",
           duration_ms: 400,
@@ -218,7 +225,6 @@ describe("query_stats", () => {
           tool_use_id: "toolu_abc1",
         },
         {
-          id: 2,
           tool_name: "list_entrypoints",
           called_at: "2026-02-17T10:02:00.000Z",
           duration_ms: 500,
@@ -229,7 +235,6 @@ describe("query_stats", () => {
           tool_use_id: null,
         },
         {
-          id: 3,
           tool_name: "show_call_graph_neighborhood",
           called_at: "2026-02-17T10:03:00.000Z",
           duration_ms: 200,
@@ -240,7 +245,6 @@ describe("query_stats", () => {
           tool_use_id: "toolu_abc3",
         },
         {
-          id: 4,
           tool_name: "list_entrypoints",
           called_at: "2026-02-17T10:04:00.000Z",
           duration_ms: 100,
@@ -256,11 +260,11 @@ describe("query_stats", () => {
     });
 
     it("returns empty array for session with no calls", () => {
-      expect(session_detail(db, "s3")).toEqual([]);
+      expect(session_detail(TOOL_CALLS, "s3")).toEqual([]);
     });
 
     it("returns empty array for non-existent session", () => {
-      expect(session_detail(db, "nonexistent")).toEqual([]);
+      expect(session_detail(TOOL_CALLS, "nonexistent")).toEqual([]);
     });
   });
 });

--- a/packages/mcp/src/analytics/query_stats.ts
+++ b/packages/mcp/src/analytics/query_stats.ts
@@ -1,4 +1,25 @@
-import Database from "better-sqlite3";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface SessionRow {
+  session_id: string;
+  started_at: string;
+  project_path: string;
+  client_name: string | null;
+  client_version: string | null;
+}
+
+export interface ToolCallRow {
+  session_id: string;
+  tool_name: string;
+  called_at: string;
+  duration_ms: number;
+  success: boolean;
+  error_message: string | null;
+  arguments: Record<string, unknown>;
+  request_id: string | null;
+  tool_use_id: string | null;
+}
 
 export interface ToolCallSummary {
   tool_name: string;
@@ -18,7 +39,6 @@ export interface SessionSummary {
 }
 
 export interface ToolCallDetail {
-  id: number;
   tool_name: string;
   called_at: string;
   duration_ms: number;
@@ -29,90 +49,109 @@ export interface ToolCallDetail {
   tool_use_id: string | null;
 }
 
-export function calls_per_tool(db: Database.Database): ToolCallSummary[] {
-  return db
-    .prepare(
-      `SELECT
-        tool_name,
-        COUNT(*) as total_calls,
-        SUM(success) as success_count,
-        COUNT(*) - SUM(success) as failure_count,
-        CAST(ROUND(AVG(duration_ms)) AS INTEGER) as avg_duration_ms
-      FROM tool_calls
-      GROUP BY tool_name
-      ORDER BY total_calls DESC`
-    )
-    .all() as ToolCallSummary[];
+function read_jsonl<T>(file_path: string): T[] {
+  try {
+    const content = fs.readFileSync(file_path, "utf-8");
+    return content
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as T);
+  } catch {
+    return [];
+  }
+}
+
+export function read_sessions(dir: string): SessionRow[] {
+  return read_jsonl<SessionRow>(path.join(dir, "sessions.jsonl"));
+}
+
+export function read_tool_calls(dir: string): ToolCallRow[] {
+  return read_jsonl<ToolCallRow>(path.join(dir, "tool_calls.jsonl"));
+}
+
+function aggregate_tool_calls(tool_calls: ToolCallRow[]): ToolCallSummary[] {
+  const groups = new Map<
+    string,
+    { total: number; success: number; duration_sum: number }
+  >();
+
+  for (const call of tool_calls) {
+    const g = groups.get(call.tool_name) ?? {
+      total: 0,
+      success: 0,
+      duration_sum: 0,
+    };
+    g.total++;
+    if (call.success) g.success++;
+    g.duration_sum += call.duration_ms;
+    groups.set(call.tool_name, g);
+  }
+
+  return Array.from(groups.entries())
+    .map(([tool_name, g]) => ({
+      tool_name,
+      total_calls: g.total,
+      success_count: g.success,
+      failure_count: g.total - g.success,
+      avg_duration_ms: Math.round(g.duration_sum / g.total),
+    }))
+    .sort((a, b) => b.total_calls - a.total_calls);
+}
+
+export function calls_per_tool(tool_calls: ToolCallRow[]): ToolCallSummary[] {
+  return aggregate_tool_calls(tool_calls);
 }
 
 export function calls_in_range(
-  db: Database.Database,
+  tool_calls: ToolCallRow[],
   from: string,
-  to: string
+  to: string,
 ): ToolCallSummary[] {
-  return db
-    .prepare(
-      `SELECT
-        tool_name,
-        COUNT(*) as total_calls,
-        SUM(success) as success_count,
-        COUNT(*) - SUM(success) as failure_count,
-        CAST(ROUND(AVG(duration_ms)) AS INTEGER) as avg_duration_ms
-      FROM tool_calls
-      WHERE called_at >= ? AND called_at <= ?
-      GROUP BY tool_name
-      ORDER BY total_calls DESC`
-    )
-    .all(from, to) as ToolCallSummary[];
+  const filtered = tool_calls.filter(
+    (c) => c.called_at >= from && c.called_at <= to,
+  );
+  return aggregate_tool_calls(filtered);
 }
 
 export function recent_sessions(
-  db: Database.Database,
-  limit: number = 5
+  sessions: SessionRow[],
+  tool_calls: ToolCallRow[],
+  limit: number = 5,
 ): SessionSummary[] {
-  return db
-    .prepare(
-      `SELECT
-        s.session_id,
-        s.started_at,
-        s.project_path,
-        s.client_name,
-        s.client_version,
-        COUNT(tc.id) as call_count
-      FROM sessions s
-      LEFT JOIN tool_calls tc ON s.session_id = tc.session_id
-      GROUP BY s.session_id
-      ORDER BY s.started_at DESC
-      LIMIT ?`
-    )
-    .all(limit) as SessionSummary[];
+  const call_counts = new Map<string, number>();
+  for (const call of tool_calls) {
+    call_counts.set(call.session_id, (call_counts.get(call.session_id) ?? 0) + 1);
+  }
+
+  return sessions
+    .slice()
+    .sort((a, b) => (a.started_at > b.started_at ? -1 : a.started_at < b.started_at ? 1 : 0))
+    .slice(0, limit)
+    .map((s) => ({
+      session_id: s.session_id,
+      started_at: s.started_at,
+      project_path: s.project_path,
+      client_name: s.client_name,
+      client_version: s.client_version,
+      call_count: call_counts.get(s.session_id) ?? 0,
+    }));
 }
 
 export function session_detail(
-  db: Database.Database,
-  session_id: string
+  tool_calls: ToolCallRow[],
+  session_id: string,
 ): ToolCallDetail[] {
-  const rows = db
-    .prepare(
-      `SELECT id, tool_name, called_at, duration_ms, success, error_message, arguments, request_id, tool_use_id
-      FROM tool_calls
-      WHERE session_id = ?
-      ORDER BY called_at ASC`
-    )
-    .all(session_id) as Array<{
-    id: number;
-    tool_name: string;
-    called_at: string;
-    duration_ms: number;
-    success: number;
-    error_message: string | null;
-    arguments: string;
-    request_id: string | null;
-    tool_use_id: string | null;
-  }>;
-
-  return rows.map((row) => ({
-    ...row,
-    success: row.success === 1,
-  }));
+  return tool_calls
+    .filter((c) => c.session_id === session_id)
+    .sort((a, b) => (a.called_at < b.called_at ? -1 : a.called_at > b.called_at ? 1 : 0))
+    .map((c) => ({
+      tool_name: c.tool_name,
+      called_at: c.called_at,
+      duration_ms: c.duration_ms,
+      success: c.success,
+      error_message: c.error_message,
+      arguments: JSON.stringify(c.arguments),
+      request_id: c.request_id,
+      tool_use_id: c.tool_use_id,
+    }));
 }

--- a/packages/mcp/src/scripts/ariadne_analytics.ts
+++ b/packages/mcp/src/scripts/ariadne_analytics.ts
@@ -1,18 +1,13 @@
 #!/usr/bin/env node
-import Database from "better-sqlite3";
-import * as path from "path";
 import {
   calls_per_tool,
   calls_in_range,
   recent_sessions,
   session_detail,
+  read_sessions,
+  read_tool_calls,
 } from "../analytics/query_stats";
-
-function resolve_db_path(): string {
-  if (process.env.ARIADNE_ANALYTICS_DB) return process.env.ARIADNE_ANALYTICS_DB;
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  return path.join(home, ".ariadne", "analytics.db");
-}
+import { resolve_analytics_dir } from "../analytics/analytics";
 
 interface CliArgs {
   since?: string;
@@ -38,13 +33,13 @@ function pad_right(str: string, len: number): string {
 }
 
 function main(): void {
-  const db_path = resolve_db_path();
-  let db: Database.Database;
+  const dir = resolve_analytics_dir();
 
-  try {
-    db = new Database(db_path, { readonly: true });
-  } catch {
-    console.error(`Cannot open analytics DB at: ${db_path}`);
+  const sessions = read_sessions(dir);
+  const tool_calls = read_tool_calls(dir);
+
+  if (sessions.length === 0 && tool_calls.length === 0) {
+    console.error(`No analytics data found in: ${dir}`);
     console.error("Analytics may not be enabled. Set ARIADNE_ANALYTICS=1 in .mcp.json");
     process.exit(1);
   }
@@ -53,10 +48,9 @@ function main(): void {
 
   if (args.session) {
     // Per-session detail view
-    const calls = session_detail(db, args.session);
+    const calls = session_detail(tool_calls, args.session);
     if (calls.length === 0) {
       console.log(`No tool calls found for session: ${args.session}`);
-      db.close();
       return;
     }
 
@@ -66,32 +60,23 @@ function main(): void {
     for (const call of calls) {
       const status = call.success ? "OK" : `FAIL: ${call.error_message}`;
       console.log(
-        `  ${call.called_at}  ${pad_right(call.tool_name, 32)} ${call.duration_ms}ms  ${status}`
+        `  ${call.called_at}  ${pad_right(call.tool_name, 32)} ${call.duration_ms}ms  ${status}`,
       );
     }
 
-    db.close();
     return;
   }
 
   // Summary view
-  const sessions = recent_sessions(db, 5);
-  const total_sessions_row = db
-    .prepare("SELECT COUNT(*) as count FROM sessions")
-    .get() as { count: number };
-  const total_calls_row = db
-    .prepare("SELECT COUNT(*) as count FROM tool_calls")
-    .get() as { count: number };
-
   console.log("Ariadne Analytics Summary");
   console.log("=========================");
-  console.log(`Total sessions: ${total_sessions_row.count}`);
-  console.log(`Total tool calls: ${total_calls_row.count}`);
+  console.log(`Total sessions: ${sessions.length}`);
+  console.log(`Total tool calls: ${tool_calls.length}`);
 
   // Tool breakdown
   const tool_stats = args.since
-    ? calls_in_range(db, `${args.since}T00:00:00.000Z`, "9999-12-31T23:59:59.999Z")
-    : calls_per_tool(db);
+    ? calls_in_range(tool_calls, `${args.since}T00:00:00.000Z`, "9999-12-31T23:59:59.999Z")
+    : calls_per_tool(tool_calls);
 
   if (tool_stats.length > 0) {
     if (args.since) {
@@ -104,26 +89,25 @@ function main(): void {
     for (const stat of tool_stats) {
       const failures = stat.failure_count > 0 ? `, ${stat.failure_count} failures` : "";
       console.log(
-        `  ${pad_right(stat.tool_name + ":", max_name_len + 1)}  ${pad_right(String(stat.total_calls) + " calls", 12)} (avg ${stat.avg_duration_ms}ms${failures})`
+        `  ${pad_right(stat.tool_name + ":", max_name_len + 1)}  ${pad_right(String(stat.total_calls) + " calls", 12)} (avg ${stat.avg_duration_ms}ms${failures})`,
       );
     }
   }
 
   // Recent sessions
-  if (sessions.length > 0) {
-    console.log(`\nRecent sessions (last ${sessions.length}):`);
-    for (const s of sessions) {
+  const recent = recent_sessions(sessions, tool_calls, 5);
+  if (recent.length > 0) {
+    console.log(`\nRecent sessions (last ${recent.length}):`);
+    for (const s of recent) {
       const client = s.client_name
         ? `${s.client_name}@${s.client_version}`
         : "unknown-client";
       const timestamp = s.started_at.slice(0, 16);
       console.log(
-        `  ${s.session_id.slice(0, 8)}  ${timestamp}  ${pad_right(client, 22)} ${pad_right(s.project_path, 30)} ${s.call_count} calls`
+        `  ${s.session_id.slice(0, 8)}  ${timestamp}  ${pad_right(client, 22)} ${pad_right(s.project_path, 30)} ${s.call_count} calls`,
       );
     }
   }
-
-  db.close();
 }
 
 main();

--- a/packages/mcp/src/start_server.test.ts
+++ b/packages/mcp/src/start_server.test.ts
@@ -32,6 +32,7 @@ vi.mock("./logger", () => ({
 vi.mock("./analytics/analytics", () => ({
   is_analytics_enabled: vi.fn().mockReturnValue(false),
   init_analytics: vi.fn(),
+  close_analytics: vi.fn(),
   record_session_client_info: vi.fn(),
 }));
 

--- a/packages/mcp/src/start_server.ts
+++ b/packages/mcp/src/start_server.ts
@@ -5,6 +5,7 @@ import { VERSION } from "./version";
 import { ProjectManager } from "./project_manager";
 import { initialize_logger, log_info } from "./logger";
 import {
+  close_analytics,
   init_analytics,
   is_analytics_enabled,
   record_session_client_info,
@@ -37,6 +38,7 @@ export async function start_server(
   const analytics_enabled = is_analytics_enabled();
   if (analytics_enabled) {
     init_analytics(project_path);
+    process.on("exit", close_analytics);
   }
 
   // Create McpServer (high-level API)

--- a/packages/mcp/src/tools/core/list_entrypoints.e2e.test.ts
+++ b/packages/mcp/src/tools/core/list_entrypoints.e2e.test.ts
@@ -34,7 +34,6 @@ describe("MCP Server E2E - list_entrypoints tool", () => {
         ...process.env,
         PROJECT_PATH: PACKAGES_CORE_PATH,
         ARIADNE_ANALYTICS: "",
-        ARIADNE_ANALYTICS_DB: ":memory:",
       },
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@3.25.76)
-      better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
@@ -122,9 +119,6 @@ importers:
         specifier: ^3.22.0
         version: 3.25.76
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.0
-        version: 7.6.13
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.30
@@ -700,9 +694,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1226,15 +1217,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bit-twiddle@1.0.2:
     resolution: {integrity: sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==}
@@ -1424,9 +1409,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -1739,10 +1721,6 @@ packages:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1792,10 +1770,6 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detective@5.2.1:
@@ -2132,10 +2106,6 @@ packages:
   execspawn@1.0.1:
     resolution: {integrity: sha512-s2k06Jy9i8CUkYe0+DxRlvtkZoOkwwfhB+Xxo5HGUtrISVW2m98jO2tr67DGRFxZwkjQqloA3v/tNtjhBRBieg==}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2213,9 +2183,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2280,9 +2247,6 @@ packages:
 
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2364,9 +2328,6 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3229,10 +3190,6 @@ packages:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minify-stream@2.1.0:
     resolution: {integrity: sha512-P5xE4EQRkn7Td54VGcgfDMFx1jmKPPIXCdcMfrbXS6cNHK4dO1LXwtYFb48hHrSmZfT+jlGImvHgSZEkbpNtCw==}
     engines: {node: '>= 6'}
@@ -3343,9 +3300,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -3390,10 +3344,6 @@ packages:
 
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
-
-  node-abi@3.87.0:
-    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
-    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -3684,12 +3634,6 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
 
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -4069,9 +4013,6 @@ packages:
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   single-line-log@1.1.2:
     resolution: {integrity: sha512-awzaaIPtYFdexLr6TBpcZSGPB6D1RInNO/qNetgaJloPDF/D0GkVtLvGEp8InfmLV7CyLyQ5fIRP+tVN/JmWQA==}
 
@@ -4283,13 +4224,6 @@ packages:
 
   tachyons@4.12.0:
     resolution: {integrity: sha512-2nA2IrYFy3raCM9fxJ2KODRGHVSZNTW3BR0YnlGsLUf1DA3pk3YfWZ/DdfbnZK6zLZS+jUenlUGJsKcA5fUiZg==}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -5510,10 +5444,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 24.10.9
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6095,16 +6025,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
   binary-extensions@2.3.0: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bit-twiddle@1.0.2: {}
 
@@ -6399,8 +6320,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  chownr@1.1.4: {}
 
   ci-info@2.0.0: {}
 
@@ -6772,10 +6691,6 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
@@ -6821,8 +6736,6 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   detect-indent@6.1.0: {}
-
-  detect-libc@2.1.2: {}
 
   detective@5.2.1:
     dependencies:
@@ -7300,8 +7213,6 @@ snapshots:
     dependencies:
       util-extend: 1.0.3
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   express-rate-limit@8.2.1(express@5.2.1):
@@ -7398,8 +7309,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -7476,8 +7385,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
-
-  fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -7576,8 +7483,6 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
-
-  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -8538,8 +8443,6 @@ snapshots:
 
   mimic-response@1.0.1: {}
 
-  mimic-response@3.1.0: {}
-
   minify-stream@2.1.0:
     dependencies:
       concat-stream: 2.0.0
@@ -8677,8 +8580,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
-
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -8731,10 +8632,6 @@ snapshots:
   no-case@2.3.2:
     dependencies:
       lower-case: 1.1.4
-
-  node-abi@3.87.0:
-    dependencies:
-      semver: 7.7.3
 
   node-addon-api@7.1.1: {}
 
@@ -9012,21 +8909,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.87.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
 
   prelude-ls@1.1.2: {}
 
@@ -9508,12 +9390,6 @@ snapshots:
 
   simple-concat@1.0.1: {}
 
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   single-line-log@1.1.2:
     dependencies:
       string-width: 1.0.2
@@ -9757,21 +9633,6 @@ snapshots:
       acorn-node: 1.8.2
 
   tachyons@4.12.0: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 


### PR DESCRIPTION
Remove better-sqlite3 dependency from the MCP server. Analytics data is now stored as append-only JSONL files (sessions.jsonl, tool_calls.jsonl) in ~/.ariadne/analytics/. This eliminates native build requirements while keeping the data trivially convertible to CSV for SQLite import via jq.